### PR TITLE
fix blank page after minting

### DIFF
--- a/src/hooks/blockchain-hooks/startfiPaymentNft.ts
+++ b/src/hooks/blockchain-hooks/startfiPaymentNft.ts
@@ -32,10 +32,10 @@ export const useMint = (): ((
             account,
             library
           )
-          return (mintedNFT as any).value.toNumber()
+          return mintedNFT as any
         } else {
           const mintedNFT = await mint('MintNFTWithoutRoyalty', [address, ipfsHash], contract, account, library)
-          return (mintedNFT as any).value.toNumber()
+          return mintedNFT as any
         }
       } catch (e) {
         console.log('error', e)


### PR DESCRIPTION
In this PR I have solved this issue https://github.com/StartFi/startfi-interface/issues/257 by returning the entire NFT object instead of number (which returned 0).